### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://testgitvs.visualstudio.com/17184730-d78a-4b21-8bf7-ef6c396c5b58/6519f9d2-3c32-411e-9ed7-2f8e8294f1da/_apis/work/boardbadge/9e8c5fdf-2754-4402-9ab4-09b4abd9bfd1)](https://testgitvs.visualstudio.com/17184730-d78a-4b21-8bf7-ef6c396c5b58/_boards/board/t/6519f9d2-3c32-411e-9ed7-2f8e8294f1da/Microsoft.RequirementCategory)
 # Exam AZ-400 Microsoft Azure DevOps Solutions Crash Course
 
 ![az-400-cover](az400-cover.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#514](https://testgitvs.visualstudio.com/17184730-d78a-4b21-8bf7-ef6c396c5b58/_workitems/edit/514). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.